### PR TITLE
Trigger on release

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -45,7 +45,6 @@ jobs:
         with:
           repository: ggml-org/llama.cpp
           ref: ${{ github.event.release.tag_name }}
-          fetch-depth: 1
 
       - name: Dependencies
         run: |


### PR DESCRIPTION
Trigger on release: artifacts added one by one to the existing release, without having to wait for all to finish. A failure will not block the release of others.

~Statically link.~ This results in 24G total artifacts for cuda build. 

Other minor refactoring.