### PR TITLE
Bundle CUDA shared objects with CUDA builds (arm64 and amd64)

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -92,7 +92,7 @@ jobs:
           # Configure and build llama.cpp
           common_flags="-D LLAMA_CURL=OFF -D GGML_NATIVE=OFF"
           artifacts_flags="-D LLAMA_BUILD_TESTS=OFF -D LLAMA_BUILD_EXAMPLES=OFF -D LLAMA_BUILD_TOOLS=ON -D LLAMA_BUILD_SERVER=ON"
-          cmake -B build -D $common_flags $artifacts_flags ${{ matrix.jobs.additional-cmake-flags }}
+          cmake -B build $common_flags $artifacts_flags ${{ matrix.jobs.additional-cmake-flags }}
           cmake --build build --config Release -j $(nproc)
 
       - name: Pack artifacts


### PR DESCRIPTION
llama-server builds with CUDA backend link to a specific major libcudart, libcublas, libcublasLT version that matches CUDA Toolkit on the build environment. 

On Ubuntu 24.04, the multiverse archive currently includes Cuda Toolkit v12.0.140. This is not sufficient for arm64 builds (see https://github.com/canonical/inference-snaps/issues/114#issuecomment-3574750857). Because of this, the workflow installs the v12.9 of toolkit from the Nvidia archive.

According to [Nvidia docs](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html), CUDA 12 is expected to be compatible with Nvidia driver >= 525. It may work on older versions with the help of [cuda-compat](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) packages. I have not tested this.

Tested the workflow at https://github.com/farshidtz/llama.cpp-builds/actions/runs/19669860921

Tested the artifacts with CUDA backend on arm64 and amd64.

Nvidia DGX Spark, Driver Version: 580.95.05:
```console
$ LD_LIBRARY_PATH=lib ldd bin/llama-server
	linux-vdso.so.1 (0x0000f003d79d9000)
	libmtmd.so.0 => lib/libmtmd.so.0 (0x0000f003d74a0000)
	libllama.so.0 => lib/libllama.so.0 (0x0000f003d7270000)
	libggml.so.0 => lib/libggml.so.0 (0x0000f003d7240000)
	libggml-base.so.0 => lib/libggml-base.so.0 (0x0000f003d7190000)
	libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000f003d6f00000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000f003d6e50000)
	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000f003d6e10000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000f003d6c50000)
	/lib/ld-linux-aarch64.so.1 (0x0000f003d7990000)
	libggml-cpu.so.0 => lib/libggml-cpu.so.0 (0x0000f003d6b00000)
	libggml-cuda.so.0 => lib/libggml-cuda.so.0 (0x0000f003ced50000)
	libgomp.so.1 => /lib/aarch64-linux-gnu/libgomp.so.1 (0x0000f003cecd0000)
	libcudart.so.12 => lib/libcudart.so.12 (0x0000f003cec00000)
	libcublas.so.12 => lib/libcublas.so.12 (0x0000f003c8880000)
	libcuda.so.1 => /lib/aarch64-linux-gnu/libcuda.so.1 (0x0000f003c2bf0000)
	libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000f003c2bc0000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000f003c2b90000)
	librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000f003c2b60000)
	libcublasLt.so.12 => lib/libcublasLt.so.12 (0x0000f00392f20000)
```

x86, 580.95.05:
```console
$ ls -lGgh lib
total 950M
lrwxrwxrwx 1   23 Nov 25 11:34 libcublasLt.so.12 -> libcublasLt.so.12.9.1.4
-rw-r--r-- 1 715M Nov 25 11:34 libcublasLt.so.12.9.1.4
lrwxrwxrwx 1   21 Nov 25 11:34 libcublas.so.12 -> libcublas.so.12.9.1.4
-rw-r--r-- 1 101M Nov 25 11:34 libcublas.so.12.9.1.4
lrwxrwxrwx 1   20 Nov 25 11:33 libcudart.so.12 -> libcudart.so.12.9.79
-rw-r--r-- 1 724K Nov 25 11:33 libcudart.so.12.9.79
lrwxrwxrwx 1   17 Nov 25 10:40 libggml-base.so -> libggml-base.so.0
lrwxrwxrwx 1   21 Nov 25 10:40 libggml-base.so.0 -> libggml-base.so.0.9.4
-rwxr-xr-x 1 729K Nov 25 10:40 libggml-base.so.0.9.4
lrwxrwxrwx 1   16 Nov 25 10:41 libggml-cpu.so -> libggml-cpu.so.0
lrwxrwxrwx 1   20 Nov 25 10:41 libggml-cpu.so.0 -> libggml-cpu.so.0.9.4
-rwxr-xr-x 1 900K Nov 25 10:41 libggml-cpu.so.0.9.4
lrwxrwxrwx 1   17 Nov 25 11:29 libggml-cuda.so -> libggml-cuda.so.0
lrwxrwxrwx 1   21 Nov 25 11:29 libggml-cuda.so.0 -> libggml-cuda.so.0.9.4
-rwxr-xr-x 1 129M Nov 25 11:29 libggml-cuda.so.0.9.4
lrwxrwxrwx 1   12 Nov 25 11:29 libggml.so -> libggml.so.0
lrwxrwxrwx 1   16 Nov 25 11:29 libggml.so.0 -> libggml.so.0.9.4
-rwxr-xr-x 1  55K Nov 25 11:29 libggml.so.0.9.4
lrwxrwxrwx 1   13 Nov 25 11:30 libllama.so -> libllama.so.0
lrwxrwxrwx 1   17 Nov 25 11:30 libllama.so.0 -> libllama.so.0.0.1
-rwxr-xr-x 1 2.7M Nov 25 11:30 libllama.so.0.0.1
lrwxrwxrwx 1   12 Nov 25 11:31 libmtmd.so -> libmtmd.so.0
lrwxrwxrwx 1   16 Nov 25 11:31 libmtmd.so.0 -> libmtmd.so.0.0.1
-rwxr-xr-x 1 812K Nov 25 11:31 libmtmd.so.0.0.1


$ LD_LIBRARY_PATH=lib ldd bin/llama-server
	linux-vdso.so.1 (0x00007c5662705000)
	libmtmd.so.0 => lib/libmtmd.so.0 (0x00007c5662143000)
	libllama.so.0 => lib/libllama.so.0 (0x00007c5661e00000)
	libggml.so.0 => lib/libggml.so.0 (0x00007c56626f3000)
	libggml-base.so.0 => lib/libggml-base.so.0 (0x00007c566209a000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007c5661a00000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007c5661d17000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007c56626b1000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007c5661600000)
	/lib64/ld-linux-x86-64.so.2 (0x00007c5662707000)
	libggml-cpu.so.0 => lib/libggml-cpu.so.0 (0x00007c56618a7000)
	libggml-cuda.so.0 => lib/libggml-cuda.so.0 (0x00007c5659600000)
	libgomp.so.1 => /lib/x86_64-linux-gnu/libgomp.so.1 (0x00007c5661cc1000)
	libcudart.so.12 => lib/libcudart.so.12 (0x00007c5659200000)
	libcublas.so.12 => lib/libcublas.so.12 (0x00007c5652a00000)
	libcuda.so.1 => /lib/x86_64-linux-gnu/libcuda.so.1 (0x00007c564cc00000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007c56626aa000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007c56626a3000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007c566269e000)
	libcublasLt.so.12 => lib/libcublasLt.so.12 (0x00007c561a800000)
```