### PR TITLE
Always build with cpu-all-variants

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -103,6 +103,7 @@ jobs:
           cp LICENSE archive/licenses/
           
           # Workaround: llama.cpp expects ggml shared objects in the same directory as executables
+          # See issue: https://github.com/ggml-org/llama.cpp/issues/17491
           pushd archive/bin/
           ln -s ../lib/libggml-cpu* ./
           ln -s ../lib/libggml-cuda* ./


### PR DESCRIPTION
Before this change:
```
$ ./llama-cli --model /snap/gemma3/components/mnt/model-4b-it-q4-0-gguf/62/gemma-3-4b-it-q4_0.gguf --gpu-layers 99
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GeForce GTX 1080 Ti, compute capability 6.1, VMM: yes
Illegal instruction (core dumped)
```

After this change:
```
$ ./llama-cli --model /snap/gemma3/components/mnt/model-4b-it-q4-0-gguf/62/gemma-3-4b-it-q4_0.gguf --gpu-layers 99
load_backend: loaded CPU backend from /home/jpmeijers/llamacpp-cuda/bin/libggml-cpu-sandybridge.so
warning: no usable GPU found, --gpu-layers option will be ignored
warning: one possible reason is that llama.cpp was compiled without GPU support
warning: consult docs/build.md for compilation instructions
build: 1 (e6923ca) with gcc-14 (Ubuntu 14.2.0-4ubuntu2~24.04) 14.2.0 for x86_64-linux-gnu
...
load_tensors:   CPU_Mapped model buffer size =  3002.65 MiB
...
system_info: n_threads = 4 (n_threads_batch = 4) / 4 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
...
>
```

Symlinking the remaining libggml-*.so files solves the problem:
```
$ ln -s ../lib/libggml-base.so .
$ ln -s ../lib/libggml-cuda.so .
$ ./llama-cli --model /snap/gemma3/components/mnt/model-4b-it-q4-0-gguf/62/gemma-3-4b-it-q4_0.gguf --gpu-layers 99
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GeForce GTX 1080 Ti, compute capability 6.1, VMM: yes
load_backend: loaded CUDA backend from /home/jpmeijers/llamacpp-cuda/bin/libggml-cuda.so
load_backend: loaded CPU backend from /home/jpmeijers/llamacpp-cuda/bin/libggml-cpu-sandybridge.so
build: 1 (e6923ca) with gcc-14 (Ubuntu 14.2.0-4ubuntu2~24.04) 14.2.0 for x86_64-linux-gnu
main: llama backend init
```