### PR TITLE
Let build scripts auto detect cuda architectures

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -28,12 +28,12 @@ jobs:
           #
           - name: amd64+cuda12
             runs-on: ubuntu-24.04
-            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=all-major"
+            additional-cmake-flags: "-D GGML_CUDA=ON"
             cuda-toolkit: true
 
           - name: arm64+cuda12
             runs-on: ubuntu-24.04-arm
-            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=all-major"
+            additional-cmake-flags: "-D GGML_CUDA=ON"
             cuda-toolkit: true
 
     runs-on: ${{ matrix.jobs.runs-on }}


### PR DESCRIPTION
Tested on NVIDIA GeForce GTX 1080 Ti, compute capability 6.1 and getting ~75TPS.

Example action run with cuda auto detection: https://github.com/jpm-canonical/llama.cpp-builds/actions/runs/20992766361/job/60342081022#step:4:81