### PR TITLE
Removing LLAMACURL=OFF compilation flag

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -85,7 +85,7 @@ jobs:
           export CUDACXX=/usr/local/cuda/bin/nvcc
           
           # Configure and build llama.cpp
-          common_flags="-D LLAMA_CURL=OFF -D GGML_NATIVE=OFF -D GGML_BACKEND_DL=ON -D GGML_CPU_ALL_VARIANTS=ON"
+          common_flags="-D GGML_NATIVE=OFF -D GGML_BACKEND_DL=ON -D GGML_CPU_ALL_VARIANTS=ON"
           artifacts_flags="-D LLAMA_BUILD_TESTS=OFF -D LLAMA_BUILD_EXAMPLES=OFF -D LLAMA_BUILD_TOOLS=ON -D LLAMA_BUILD_SERVER=ON"
           cmake -B build $common_flags $artifacts_flags ${{ matrix.jobs.additional-cmake-flags }}
           cmake --build build --config Release -j $(nproc)


### PR DESCRIPTION
The compilation flag LLAMACURL was deprecated by llama.cpp at the beginning of 2026. It is now ineffective and the library has been replaced by OPENSSL.