### PR TITLE
Update CUDA build flags for amd64 and arm64

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -28,12 +28,12 @@ jobs:
           #
           - name: amd64+cuda12
             runs-on: ubuntu-24.04
-            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=50;52;61;70;75;80;86;89;90"
+            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=\"50;52;61;70;75;80;86;89;90\""
             cuda-toolkit: true
 
           - name: arm64+cuda12
             runs-on: ubuntu-24.04-arm
-            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=50;52;61;70;75;80;86;89;90"
+            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=\"50;52;61;70;75;80;86;89;90\""
             cuda-toolkit: true
 
     runs-on: ${{ matrix.jobs.runs-on }}

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -28,12 +28,12 @@ jobs:
           #
           - name: amd64+cuda12
             runs-on: ubuntu-24.04
-            additional-cmake-flags: "-D GGML_CUDA=ON"
+            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=all"
             cuda-toolkit: true
 
           - name: arm64+cuda12
             runs-on: ubuntu-24.04-arm
-            additional-cmake-flags: "-D GGML_CUDA=ON"
+            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=all"
             cuda-toolkit: true
 
     runs-on: ${{ matrix.jobs.runs-on }}

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -28,12 +28,12 @@ jobs:
           #
           - name: amd64+cuda12
             runs-on: ubuntu-24.04
-            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=all"
+            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=50;52;61;70;75;80;86;89;90"
             cuda-toolkit: true
 
           - name: arm64+cuda12
             runs-on: ubuntu-24.04-arm
-            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=all"
+            additional-cmake-flags: "-D GGML_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=50;52;61;70;75;80;86;89;90"
             cuda-toolkit: true
 
     runs-on: ${{ matrix.jobs.runs-on }}


### PR DESCRIPTION
Added CMAKE_CUDA_ARCHITECTURES flag to CUDA build.

Build succeeded: https://github.com/canonical/llama.cpp-builds/actions/runs/23588986888
Newer llamacpp: https://github.com/canonical/llama.cpp-builds/actions/runs/24769372788

TODO: test llamacpp artifacts on Ubuntu 24.04 with driver <580